### PR TITLE
Workflow Fixes

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -80,7 +80,7 @@ jobs:
         run: echo "::set-output name=version::$(grep '^version =' tool_calling_derive/Cargo.toml | cut -d '"' -f 2)"
 
       - name: Update Cargo.toml for main crate dependency
-        run: sed -i "s|tool_calling_derive = {.*path.*}|tool_calling_derive = \\"${{ steps.get_derive_version.outputs.version }}\\"|" Cargo.toml
+        run: sed -i 's|tool_calling_derive = {.*path.*}|tool_calling_derive = "${{ steps.get_derive_version.outputs.version }}"|' Cargo.toml
 
       - name: Publish tool_calling crate
         env:

--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -89,7 +89,7 @@ jobs:
 
   create_github_release:
     name: Create Github Release
-    needs: build
+    needs: publish_to_crates_io
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/build_and_release.yaml` file to fix a syntax issue and adjust the workflow dependencies for the GitHub release process.

Workflow improvements:

* Fixed a syntax issue in the `sed` command used to update the `Cargo.toml` file by replacing double quotes with single quotes around the command. (`[.github/workflows/build_and_release.yamlL83-R83](diffhunk://#diff-556d02bcda8f77234fc28cdf65ea2d4ae0428e366864c930480da5b56b881414L83-R83)`)
* Updated the `create_github_release` job to depend on the `publish_to_crates_io` job instead of the `build` job, ensuring proper sequencing in the workflow. (`[.github/workflows/build_and_release.yamlL92-R92](diffhunk://#diff-556d02bcda8f77234fc28cdf65ea2d4ae0428e366864c930480da5b56b881414L92-R92)`)