### PR TITLE
Updates to the GitHub Actions workflow and minor formatting changes to the `README.md` file.

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -72,7 +72,7 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: |
           cd tool_calling_macros
-          cargo publish --locked
+          cargo publish
           cd .. # Go back to the root directory
 
       - name: Extract derive crate version
@@ -85,7 +85,7 @@ jobs:
       - name: Publish tool_calling crate
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        run: cargo publish --locked
+        run: cargo publish
 
   create_github_release:
     name: Create Github Release

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
 Or use cargo:
+
 ```shell
 cargo add tool_calling
 cargo add tokio --features macros,rt-multi-thread
@@ -175,6 +176,7 @@ Explore the examples directory for more usage scenarios:
 ## Testing
 
 Run the full test suite:
+
 ```bash
 cargo test
 ```
@@ -197,6 +199,7 @@ cargo test
 ### Error Handling
 
 `ToolError` variants:
+
 - `NotFound(String)` — Tool name not registered.
 - `BadArgs(String)` — Arguments missing or failed JSON Schema validation.
 - `Execution(String)` — Underlying function panicked or returned an execution error.


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow and minor formatting changes to the `README.md` file. The most significant changes include removing the `--locked` flag from `cargo publish` commands and adding spacing for improved readability in the documentation.

### Workflow updates:
* [`.github/workflows/build_and_release.yaml`](diffhunk://#diff-556d02bcda8f77234fc28cdf65ea2d4ae0428e366864c930480da5b56b881414L75-R75): Removed the `--locked` flag from `cargo publish` commands in the `tool_calling_macros` and `tool_calling` crate publishing steps to simplify the publishing process. [[1]](diffhunk://#diff-556d02bcda8f77234fc28cdf65ea2d4ae0428e366864c930480da5b56b881414L75-R75) [[2]](diffhunk://#diff-556d02bcda8f77234fc28cdf65ea2d4ae0428e366864c930480da5b56b881414L88-R88)

### Documentation formatting:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32): Added blank lines before code blocks and list items to improve readability in sections such as "Or use cargo," "Testing," and "Error Handling." [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R179) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R202)