### PR TITLE
Version Bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "tool_calling_macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "futures",
  "inventory",

--- a/tool_calling_macros/Cargo.toml
+++ b/tool_calling_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tool_calling_macros"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Procedural macros for tool_calling crate"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This pull request updates the version of the `tool_calling_macros` crate to reflect changes made in the project.

Version update:

* [`tool_calling_macros/Cargo.toml`](diffhunk://#diff-927c897d3c9bd37dc1c9763483e143d916ddbc8e7c9eae11198dcce59da1bebaL3-R3): Incremented the version of the crate from `0.1.0` to `0.1.1` to indicate a new release with updates.