### PR TITLE
Remove Unused Workflow steps

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -75,13 +75,6 @@ jobs:
           cargo publish
           cd .. # Go back to the root directory
 
-      - name: Extract derive crate version
-        id: get_derive_version
-        run: echo "::set-output name=version::$(grep '^version =' tool_calling_macros/Cargo.toml | cut -d '"' -f 2)"
-
-      - name: Update Cargo.toml for main crate dependency
-        run: sed -i 's|tool_calling_macros = {.*path.*}|tool_calling_macros = "${{ steps.get_derive_version.outputs.version }}"|' Cargo.toml
-
       - name: Publish tool_calling crate
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
This pull request simplifies the GitHub Actions workflow for building and releasing the project by removing unnecessary steps related to extracting and updating the version of the `tool_calling_macros` crate.

Workflow simplification:

* [`.github/workflows/build_and_release.yaml`](diffhunk://#diff-556d02bcda8f77234fc28cdf65ea2d4ae0428e366864c930480da5b56b881414L78-L84): Removed the steps for extracting the `derive` crate version and updating the `Cargo.toml` dependency for the main crate, as these steps were no longer necessary.