### PR TITLE
version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "tool_calling_macros"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "futures",
  "inventory",

--- a/tool_calling_macros/Cargo.toml
+++ b/tool_calling_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tool_calling_macros"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Procedural macros for tool_calling crate"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This pull request includes a version bump for the `tool_calling_macros` crate in its `Cargo.toml` file, updating it from version `0.1.1` to `0.1.2`.